### PR TITLE
fix sonar-scanner import error when empty line

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pylint-sonarjson",
-    version="2.0.0",
+    version="2.0.1",
     author="Teake Nutma, Topin2001",
     description="A PyLint plugin that can output to SonarQube-importable JSON",
     long_description=long_description,

--- a/src/pylint_sonarjson/sonarjson_reporter.py
+++ b/src/pylint_sonarjson/sonarjson_reporter.py
@@ -42,13 +42,14 @@ class SonarJSONReporter(BaseReporter):
                 "message": msg.msg or "",
                 "filePath": msg.path,
                 "textRange": {
-                    "startLine": msg.line,
-                    "startColumn": msg.column,
+                    "startLine": msg.line
                 }
             },
             "severity": self.sonar_checker.severity(msg),
             "effortMinutes": self.sonar_checker.effort(msg)
         }
+        if hasattr(msg, "column") and msg.column > 0:
+            sonar_dict["primaryLocation"]["textRange"]["startColumn"] = msg.column
         if hasattr(msg, "end_line") and msg.end_line:
             sonar_dict["primaryLocation"]["textRange"]["endLine"] = msg.end_line
             if hasattr(msg, "end_column") and msg.end_column:


### PR DESCRIPTION
## Proposed changes

This applies [Turiok](https://github.com/Turiok)'s PR [sonar-scanner import error when empty line](https://github.com/omegacen/pylint-sonarjson/pull/8) made to [omegacen/pylint-sonarjson](https://github.com/omegacen/pylint-sonarjson).

SonarScanner does not expect startColumn to be included in the report JSON for issues on empty lines because empty lines do not have columns. With this change, startColumn is omitted if the message column is not greater than 0.

More context here: https://sonarsource.atlassian.net/browse/SONAR-20958

## Types of changes

What types of changes does your code introduce to this project?
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Issues closed by changes

- [x] Close [#7 from parent repo](https://github.com/omegacen/pylint-sonarjson/issues/7#issuecomment-1398138154)
